### PR TITLE
Track a global view cache version

### DIFF
--- a/lib/interlatch.rb
+++ b/lib/interlatch.rb
@@ -4,7 +4,9 @@ require 'interlatch/rails'
 module Interlatch
   extend self
 
-  def caching_key(controller, action, id, tag, locale, watermark)
+  def caching_key(controller, action, id, tag, locale)
+    cache_version = cache_version_hook ? cache_version_hook.call : nil
+      
     parts = [
       "interlatch",
       ENV['RAILS_ASSET_ID'],
@@ -13,7 +15,7 @@ module Interlatch
       id || 'all',
       tag || 'untagged',
       locale,
-      watermark
+      cache_version
     ].compact.join(":")
   end
 
@@ -31,5 +33,5 @@ module Interlatch
     end
   end
 
-  mattr_accessor :locale_method, :add_clear_caching_links, :watermark_method
+  mattr_accessor :locale_method, :add_clear_caching_links, :cache_version_hook
 end

--- a/lib/interlatch/rails/extensions/action_controller.rb
+++ b/lib/interlatch/rails/extensions/action_controller.rb
@@ -12,9 +12,8 @@ module Interlatch
             options.merge! id: 'any'
           end
           locale = Interlatch.locale_method ? self.send(Interlatch.locale_method) : nil
-          watermark = Interlatch.watermark_method ? self.send(Interlatch.watermark_method) : nil
 
-          Interlatch.caching_key(options[:controller], options[:action], options[:id], options[:tag], locale, watermark)
+          Interlatch.caching_key(options[:controller], options[:action], options[:id], options[:tag], locale)
         end
 
         def behavior_cache(*args, &block)

--- a/test/interlatch_test.rb
+++ b/test/interlatch_test.rb
@@ -1,5 +1,4 @@
 require_relative 'test_helper'
-require 'set'
 
 ActiveRecord::Base.establish_connection 'test'
 class Foo < ActiveRecord::Base
@@ -68,10 +67,6 @@ class TestController < ActionController::Base
   private
   def current_locale
     'en_us'
-  end
-
-  def current_watermark
-    '54321'
   end
 end
 
@@ -321,15 +316,17 @@ class InterlatchTest < ActionController::TestCase
     assert_equal 'foo', assigns(:foo)
   end
 
-  def test_watermark
+  def test_cache_version_hook
     begin
-      Interlatch.watermark_method = :current_watermark
+      Interlatch.cache_version_hook = lambda do
+        "54321"
+      end
 
       get :no_args, id: '4'
 
       assert_equal "\nHI\n", @store.read('views/interlatch:8675309:test:no_args:4:untagged:54321')
     ensure
-      Interlatch.watermark_method = nil
+      Interlatch.cache_version_hook = nil
     end
   end
 end


### PR DESCRIPTION
Allow setting a global hook function that will return a cache version to put in the caching key.
